### PR TITLE
need special handling for 4xx, 5xx response codes 

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,7 @@
+2.0.2 / 2015-07-17
+==================
+
+  - updated response handler to treat 4xx and 5xx status codes as acceptable
 
 2.0.1 / 2015-04-17
 ==================

--- a/lib/http-driver.js
+++ b/lib/http-driver.js
@@ -25,7 +25,7 @@ function driver(opts) {
       .get(ctx.url)
       .set(ctx.headers)
       .end(function(err, res) {
-        if (err) return fn(err)
+        if (err && !err.status) return fn(err)
 
         ctx.status = res.status
         ctx.set(res.headers)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "x-ray-crawler",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "x-ray's crawler",
   "main": "lib/index.js",
   "dependencies": {


### PR DESCRIPTION
superagent treats these responses as node errors, so x-ray thinks something went wrong with the request and errors out. I think this is bad behavior, especially if we're crawling multiple links. One down server will kill the whole scrape.