### PR TITLE
fix(#6): upgrade vulnerable dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,10 +10,10 @@
     "emitter-component": "^1.1.1",
     "enqueue": "^1.0.2",
     "http-context": "^1.1.0",
-    "ms": "^0.7.0",
+    "ms": "^2.0.0",
     "selectn": "^0.9.6",
     "sliced": "0.0.5",
-    "superagent": "^1.1.0",
+    "superagent": "^3.6.0",
     "wrap-fn": "^0.1.4",
     "x-ray-parse": "^1.0.0",
     "yieldly": "0.0.1"


### PR DESCRIPTION
Just upgraded the vulnerable dependencies.
Not sure if the tests are passing, as the `npm test` command fails (no Makefile).

Fixes issue https://github.com/lapwinglabs/x-ray-crawler/issues/6.